### PR TITLE
fix: use style.textContent instead of innerHTML for injected <style>

### DIFF
--- a/pbinfo-get-unsolved-enhanced.js
+++ b/pbinfo-get-unsolved-enhanced.js
@@ -1133,7 +1133,7 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
 
     const style = document.createElement('style');
     style.id = UI_STYLE_ID;
-    style.innerHTML = `
+    style.textContent = `
         #${UI_ROOT_ID}{
             font-family: Arial, sans-serif;
             --bg: #ffffff;


### PR DESCRIPTION
Clears SonarCloud `jssecurity:S5696` (DOM-XSS) at `pbinfo-get-unsolved-enhanced.js`.

The injected `<style>` block is built **only from compile-time constant `UI_*` id literals** (`UI_ROOT_ID`, `UI_ID_LOG`, etc. — all string literals, no user/network/DOM taint), so it was not exploitable. But `textContent` is the correct API for a `<style>` element's plain-CSS content and removes the finding at its root.

No behavior change. `npm test` 118/118 pass, lint/format/build clean.