### PR TITLE
fix(deps): bump js-yaml 4.2.0 -> 4.3.0 (GHSA-52cp-r559-cp3m)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -990,9 +990,9 @@
       "license": "ISC"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
fix(deps): bump js-yaml 4.2.0 -> 4.3.0 (GHSA-52cp-r559-cp3m)

js-yaml: YAML merge-key chains can force quadratic CPU consumption
(CVE-2026-59869, HIGH).

Advisory has two ranges: [3.0.0, 3.15.0) and [4.0.0, 4.3.0). The resolved
version 4.2.0 sits in the 4.x range, so the applicable fix is 4.3.0 -- which
is also the forward floor (max fixed across both ranges), so no later 4.x bump
can land in a higher vulnerable window.

js-yaml is a transitive devDependency via @eslint/eslintrc, whose range is
already "^4.1.1" = >=4.1.1 <5.0.0 and therefore already admits 4.3.0. No
overrides entry is needed; only the lockfile was stale. Verified by mutation:
`npm update js-yaml --package-lock-only` moves it with no manifest change.

Verification (local, and CI runs the same gates):
- osv-scanner 2.3.8 finding-set diff base vs head: GHSA-52cp-r559-cp3m gone,
  zero new findings.
- npm ci installs js-yaml 4.3.0 (not just recorded in the lock).
- npm test: 118 passed / 0 failed; test:coverage 100% lines/branches/functions.
- npm run lint: clean -- this is the reachability path, since eslint loads
  configs through @eslint/eslintrc -> js-yaml.

Not addressed here: brace-expansion (GHSA-3jxr-9vmj-r5cp, GHSA-mh99-v99m-4gvg)
is present on both sides and is deliberately out of scope -- it has no
non-breaking fix (5.0.8 changes the module export from a function to an object,
which breaks minimatch 3.x's `expand = require('brace-expansion'); expand(p)`).
