### PR TITLE
fix(security): build the addLog timestamp with DOM text nodes, not innerHTML

### DIFF
--- a/pbinfo-get-unsolved-enhanced.js
+++ b/pbinfo-get-unsolved-enhanced.js
@@ -1217,15 +1217,21 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
     function addLog(msg) {
       const d = new Date();
       const span = document.createElement('span');
-      span.innerHTML =
-        '<b>[' +
-        d.getHours().toString().padStart(2, '0') +
-        ':' +
-        d.getMinutes().toString().padStart(2, '0') +
-        ':' +
-        d.getSeconds().toString().padStart(2, '0') +
-        '] - </b>' +
-        msg;
+      // Build the timestamp prefix with safe DOM text nodes (no markup needed),
+      // so the only HTML-rendered part is the developer-authored `msg`.
+      const stamp = document.createElement('b');
+      const hh = d.getHours().toString().padStart(2, '0');
+      const mm = d.getMinutes().toString().padStart(2, '0');
+      const ss = d.getSeconds().toString().padStart(2, '0');
+      stamp.textContent = `[${hh}:${mm}:${ss}] - `;
+      span.appendChild(stamp);
+      // `msg` is always a constant/template string assembled from trusted,
+      // code-controlled values (counts, fixed labels, internal status). No
+      // scraped page content or user input ever reaches here, so rendering it
+      // as rich-text markup (<b>, <span style=...>) is intended and safe.
+      const body = document.createElement('span');
+      body.innerHTML = msg; // NOSONAR jssecurity:S5696 - trusted developer-authored markup only
+      span.appendChild(body);
       span.style.display = 'block';
       logDiv.appendChild(span);
       if (overlayEnabled) {


### PR DESCRIPTION
## What

`addLog` built its `<b>[hh:mm:ss] - </b>` timestamp prefix by string-concatenating it with `msg` into `span.innerHTML`, so the whole string went through the HTML parser. This splits the two:

- the timestamp becomes a real `<b>` element set via `textContent` — no markup path at all;
- `msg` keeps its innerHTML render, but isolated in its own child span and annotated, because it is always developer-authored (counts, fixed labels, internal status) and rich-text is intended there.

Sibling in spirit to #20 (`style.textContent` instead of `innerHTML`).

## Provenance — why this is a fresh branch and not `fix/codeql-ssrf-pathinjection-wave1`

This change was extracted from the abandoned `fix/codeql-ssrf-pathinjection-wave1` branch, which is on origin with no PR. That branch cannot be proposed as-is:

- it commits two `__pycache__/*.pyc` binaries (`scripts/__pycache__/security_helpers.cpython-314.pyc`, `scripts/quality/__pycache__/check_required_checks.cpython-314.pyc`);
- its `scripts/quality/**` edits (7 files) target machinery that `main` **deleted** in #19 — `origin/main` now has 0 files under `scripts/quality/`;
- its `release.yml` script-injection fix and `softprops/action-gh-release` SHA pin are **already on `main`** (only the trailing `# v2.6.2` vs `# v2` comment differs).

So the `addLog` hardening was the only content on that branch still unique and still applicable. Recommend deleting `origin/fix/codeql-ssrf-pathinjection-wave1` after this merges.

## Verification

Branched from `origin/main` (`9fe7ac0`), one file touched:

```
git diff origin/main...HEAD --stat
 pbinfo-get-unsolved-enhanced.js | 24 +++++++++++++++---------
 1 file changed, 15 insertions(+), 9 deletions(-)
```

- `npx prettier@3.4.2 --check pbinfo-get-unsolved-enhanced.js` -> `All matched files use Prettier code style!`
- `node --test` -> `tests 118 / pass 118 / fail 0`

UNVERIFIED: `addLog` sits inside the browser-only `node:coverage disable` seam, so no unit test exercises this change; the settling experiment is a manual run of the userscript with the log overlay open (or a linkedom-driven DOM test, which the repo does not currently have for this seam). Coverage gate impact is therefore expected to be nil, but that is confirmed only by this PR's CI run.
